### PR TITLE
Remove redunant line for already binded setting

### DIFF
--- a/src/IDEApplication.vala
+++ b/src/IDEApplication.vala
@@ -69,8 +69,6 @@ namespace IDE {
             var settings = IDESettings.get_default ();
             settings.schema.bind ("dark-theme", gtk_settings, "gtk-application-prefer-dark-theme", SettingsBindFlags.DEFAULT);
 
-            gtk_settings.gtk_application_prefer_dark_theme = settings.dark_theme;
-
             window.show_all ();
         }
     }


### PR DESCRIPTION
The statement is redundant because the binding is already active (it works
even without explicitly setting it)
